### PR TITLE
Fix code block margin-bottom (priority conflict with Prism styles)

### DIFF
--- a/style.css
+++ b/style.css
@@ -456,6 +456,7 @@ button::-moz-focus-inner {
 .post-entry ul,
 .post-entry ol,
 .post-entry pre,
+.post-entry pre[class*="lang"],
 .post-entry h4,
 .post-entry h5,
 .post-entry h6,
@@ -561,6 +562,7 @@ button::-moz-focus-inner {
 	}
 
 .post-entry pre,
+.post-entry pre[class*="lang"],
 .post-entry .side-by-side-code {
 	margin-bottom: 1.5em;
 }


### PR DESCRIPTION
Les titres ou paragraphes qui apparaissent après un bloc de code sont trop proches de ce bloc de code, ce qui est gênant en particulier pour les titres.

![screenshot](https://user-images.githubusercontent.com/243601/68546414-2cef8200-03d6-11ea-90c2-97e30a774799.png)

Le problème vient des styles de Prism qui ont la même spécificité (`0,1,1`) et sont appelés en deuxième, prenant le pas sur le style déclaré dans `style.css`.

Je propose un correctif mais d'autres approches sont possibles, ne pas hésiter à modifier ou fermer cette PR si vous voulez le gérer autrement. :)